### PR TITLE
feat: add pr-knowledge:init and make pr-knowledge:collect config-driven

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -23,6 +23,7 @@
   "skills": [
     "./skills/commit",
     "./skills/pr-knowledge/collect",
+    "./skills/pr-knowledge/init",
     "./skills/review-after",
     "./skills/review-coverage",
     "./skills/review-note",

--- a/README.ja.md
+++ b/README.ja.md
@@ -49,6 +49,7 @@
 
 | スキル | 用途 | 状態 |
 |--------|------|------|
+| `pr-knowledge:init` | `pr-knowledge:collect` が使う `.knowledge/` バンドルの初期化 | ✅ 利用可能 |
 | `pr-knowledge:collect` | マージ済みPRからの知見抽出・蓄積 | ✅ 利用可能 |
 
 ### `review-security`
@@ -112,13 +113,21 @@ Conventional Commits形式で、Claude Codeの自動生成フッターなしでG
 
 ---
 
+### `pr-knowledge:init`
+
+`pr-knowledge:collect` が読み書きする `.knowledge/` バンドルを初期化します。ベースブランチ、タイムゾーン、知見の `type` 一覧、記述言語、除外する作成者・ラベルをヒアリングし、`.knowledge/config.json`、type別ディレクトリ、`index.md`、フロントマター雛形（`_template.md`）を生成します。生成するのは設定と器のみで、サンプルやダミーの知見は一切書きません。再実行しても安全で、既存の `config.json` がある場合は内容を提示したうえで、明示的な指示があった項目だけを更新します（無確認での上書きはしません）。
+
+**推奨**: リポジトリの知見バンドルの初回セットアップ、ベースブランチ・タイムゾーン・typeをプロジェクトの運用変更に合わせて見直すとき
+
+---
+
 ### `pr-knowledge:collect`
 
 マージ済みPRから、差分だけでなく**レビューでの議論**も読み取り、再利用可能な知見をOKF形式（簡易版）のMarkdownとして `.knowledge/` に蓄積します。機能の振る舞い、ドメイン知識、アーキテクチャの設計判断、開発Tips、コード規約を抽出し、既存の記述と突き合わせて重複を避けます。日付・期間・PR番号を指定して呼び出します（例:「2026-08-25にマージされたPRから知見を記録して」）。
 
 **推奨**: PR履歴からの知見ベース構築、レビューでしか残らない設計判断の記録、実態に即したオンボーディング資料の維持
 
-**補足**: `.knowledge/` に直接書き込む「ファイル更新モード」と、書き込まずに構造化された結果を返す「返却モード」（オーケストレータ配下のワーカーとして使う場合）の両方をサポートします。
+**補足**: 事前に初期化済みのバンドルが必要です。`.knowledge/config.json` が無い場合は先に `pr-knowledge:init` を実行してください。`.knowledge/` に直接書き込む「ファイル更新モード」と、書き込まずに構造化された結果を返す「返却モード」（オーケストレータ配下のワーカーとして使う場合）の両方をサポートします。
 
 ## インストール方法
 
@@ -180,7 +189,9 @@ your-project/
         ├── commit/
         │   └── SKILL.md
         ├── pr-knowledge/
-        │   └── collect/
+        │   ├── collect/
+        │   │   └── SKILL.md
+        │   └── init/
         │       └── SKILL.md
         ├── review-security/
         │   └── SKILL.md
@@ -212,7 +223,9 @@ custom-prompts/
     ├── commit/
     │   └── SKILL.md
     ├── pr-knowledge/
-    │   └── collect/
+    │   ├── collect/
+    │   │   └── SKILL.md
+    │   └── init/
     │       └── SKILL.md
     ├── review-security/
     │   └── SKILL.md

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Skills can be invoked explicitly by name (e.g. `/review-security`) or triggered 
 
 | Skill | Purpose | Status |
 |-------|---------|--------|
+| `pr-knowledge:init` | Initialize the `.knowledge/` bundle used by `pr-knowledge:collect` | ✅ Available |
 | `pr-knowledge:collect` | Extract and accumulate knowledge from merged PRs | ✅ Available |
 
 #### `review-security`
@@ -112,13 +113,21 @@ Creates git commits using Conventional Commits format without Claude Code's auto
 
 ---
 
+#### `pr-knowledge:init`
+
+Initializes the `.knowledge/` bundle that `pr-knowledge:collect` reads and writes: interviews you for base branches, timezone, the set of knowledge `type`s, description language, and author/label exclusions, then generates `.knowledge/config.json`, the per-type directories, `index.md`, and a frontmatter template (`_template.md`). Writes configuration and scaffolding only — never sample or placeholder knowledge entries. Safe to re-run: an existing `config.json` is shown back to you and only changed on explicit instruction, never silently overwritten.
+
+**Best for**: First-time setup of a repository's knowledge bundle, or revisiting base branches/timezone/types after the project's workflow changes.
+
+---
+
 #### `pr-knowledge:collect`
 
 Extracts reusable knowledge from merged PRs — reading both the diff and the review discussion — and accumulates it as OKF-style (simplified) Markdown under `.knowledge/`. Captures feature behavior, domain knowledge, architecture decisions, dev tips, and code conventions, deduplicating against existing entries. Invoke with a date, date range, or PR numbers (e.g. "record knowledge from the PRs merged on 2026-08-25").
 
 **Best for**: Building a searchable knowledge base from PR history, capturing design rationale that only exists in review threads, onboarding docs that stay current with actual team decisions.
 
-**Note**: Supports both a file-update mode (writes directly to `.knowledge/`) and a return mode (returns structured findings without writing, for use as a sub-agent worker under an orchestrator).
+**Note**: Requires an initialized bundle — run `pr-knowledge:init` first if `.knowledge/config.json` doesn't exist yet. Supports both a file-update mode (writes directly to `.knowledge/`) and a return mode (returns structured findings without writing, for use as a sub-agent worker under an orchestrator).
 
 ### Installation
 
@@ -180,7 +189,9 @@ your-project/
         ├── commit/
         │   └── SKILL.md
         ├── pr-knowledge/
-        │   └── collect/
+        │   ├── collect/
+        │   │   └── SKILL.md
+        │   └── init/
         │       └── SKILL.md
         ├── review-security/
         │   └── SKILL.md
@@ -212,7 +223,9 @@ custom-prompts/
     ├── commit/
     │   └── SKILL.md
     ├── pr-knowledge/
-    │   └── collect/
+    │   ├── collect/
+    │   │   └── SKILL.md
+    │   └── init/
     │       └── SKILL.md
     ├── review-security/
     │   └── SKILL.md

--- a/skills/pr-knowledge/collect/SKILL.md
+++ b/skills/pr-knowledge/collect/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: collect
-description: マージ済みPRから知見を抽出し .knowledge/ に蓄積する。差分とレビュー議論の両方を読み、機能・ドメイン知識、アーキテクチャ、開発Tips、コード規約を、OKF形式（簡易版）のMarkdownとして記録・更新する。「YYYY-MM-DDのPRから知見を記録して」「このPR群の知見を返して」のように、日付またはPR番号を伴って呼ばれたときに使う。単なるPR一覧・要約、リリースノートやCHANGELOGの作成には使わない。pr-knowledgeファミリー（pr-knowledge:collect / pr-knowledge:orchestrate）の収集役。
+description: マージ済みPRから知見を抽出し .knowledge/ に蓄積する。差分とレビュー議論の両方を読み、機能・ドメイン知識、アーキテクチャ、開発Tips、コード規約を、OKF形式（簡易版）のMarkdownとして記録・更新する。「YYYY-MM-DDのPRから知見を記録して」「このPR群の知見を返して」のように、日付またはPR番号を伴って呼ばれたときに使う。単なるPR一覧・要約、リリースノートやCHANGELOGの作成には使わない。`.knowledge/` が未初期化なら pr-knowledge:init の実行を促して停止する。pr-knowledgeファミリー（pr-knowledge:collect / pr-knowledge:init / pr-knowledge:orchestrate）の収集役。
 license: MIT
 metadata:
   author: IsodaZen
-  version: "1.0.0"
+  version: "2.0.0"
 ---
 
 # PR知見蓄積スキル（collect）
@@ -72,6 +72,7 @@ $pr-knowledge:collect #123 #124 #131
       "title": "集約境界の切り方",
       "description": "一行要約",
       "tags": ["ddd", "設計判断"],
+      "status": "confirmed",
       "body": "## 要点\n...\n\n## 詳細\n...",
       "sources": ["https://github.com/org/repo/pull/123"],
       "existing_file": ".knowledge/architecture/aggregate-boundaries.md",
@@ -96,24 +97,57 @@ $pr-knowledge:collect #123 #124 #131
 1. カレントディレクトリがGitリポジトリである（`git rev-parse --show-toplevel`）
 2. `gh` が使え、認証済みである（`gh auth status`）
 3. リポジトリがGitHubリモートを持つ（`gh repo view --json nameWithOwner`）
+4. `.knowledge/config.json` が存在する
 
 以降のパスはリポジトリルート基準。`gh api` の `{owner}` `{repo}` は gh が現在のリポジトリから自動置換するため、**手で書き換えない。**
+
+### 設定の読み込み
+
+作業前に必ず `.knowledge/config.json` を読む。ここが全パラメータの単一の情報源。
+
+```bash
+cat .knowledge/config.json
+```
+
+| キー | 用途 |
+| :--- | :--- |
+| `schema_version` | 互換性チェック。**`1` 以外なら停止する** |
+| `base_branches` | 手順1の検索条件。**推測しない** |
+| `timezone` | 日付境界の解釈 |
+| `types` | 使用可能な `type` 値とディレクトリ対応 |
+| `exclude_authors` / `exclude_labels` | 検索段階での除外 |
+| `pr_search_limit` | 手順1の取得上限 |
+| `language` | 知見本文の記述言語 |
+| `frontmatter` / `body_sections` / `status_values` | 出力フォーマット |
+
+バンドルのルートは `.knowledge/` 固定。
+
+**以下の場合は自分で作成・修復せず、`pr-knowledge:init` の実行を促して停止する。**
+
+- `config.json` が存在しない
+- JSONとしてパースできない
+- `schema_version` が `1` でない
+
+ベースブランチやタイムゾーンを推測で埋めると、対象PRが丸ごとズレる。
 
 ## 手順
 
 ### 1. 対象PRを特定する
 
+検索条件は `config.json` から組み立てる。
+
 ```bash
-gh pr list --state merged --limit 100 \
-  --search "merged:<DATE> base:<DEFAULT_BRANCH> -author:app/dependabot -author:app/renovate" \
+gh pr list --state merged --limit <pr_search_limit> \
+  --search "merged:<DATE> base:<BASE> -author:<EXCLUDED> -label:<EXCLUDED>" \
   --json number,title,url,author,mergedAt,labels
 ```
 
-- `<DEFAULT_BRANCH>` は `gh repo view --json defaultBranchRef` で取得する。リリースブランチやトピックブランチへのマージを拾わないため、ベースブランチは必ず絞る。運用が異なるリポジトリでは呼び出し側に確認する。
-- GitHubの検索はUTC基準。ローカル日付（例: JST）が意図なら境界を明示する:
+- `base:` は `base_branches` の各要素。複数ある場合はブランチごとに検索し、結果を結合して重複を除く（GitHub検索の `base:` はOR結合できない）。
+- `-author:` は `exclude_authors`、`-label:` は `exclude_labels` の各要素を並べる。
+- 日付境界は `timezone` で解釈する。GitHubの検索はUTC基準なので、`Asia/Tokyo` なら明示する:
   `merged:<DATE>T00:00:00+09:00..<DATE>T23:59:59+09:00`
-  タイムゾーンが不明なら確認する。
 - 該当0件なら報告して終了。ファイルは作らない。
+- **取得件数が `pr_search_limit` に達した場合は、取りこぼしがある前提で報告する。** 黙って先へ進まない。対象期間を分割して再実行するよう促す。
 - PR番号が直接指定された場合はこの手順を飛ばす。
 
 ### 2. 各PRの本文と差分を読む
@@ -169,10 +203,13 @@ gh api repos/{owner}/{repo}/issues/<番号>/comments --paginate
 
 - 結論が出ないまま時間切れでマージ → `deferred` に回す
 - 「今回は見送り、次で対応」と方針が明示されている → 知見として記録し、本文に「未対応の課題」として明記する
+- 方針は決まったが根拠が弱い（一人の意見のみ、検証なし） → 記録するが、フロントマターに `status: draft` を付けて確度を示す
 
 ### 4. 知見を抽出する
 
 **PRの要約を作るのではない。** 「次に同じ領域を触る人が知らないと損をすること」だけを拾う。
+
+**使える `type` は `config.json` の `types[].id` がすべて。** ここに無い値を新設しない。既定構成では以下。
 
 | type | 拾うもの |
 | :--- | :--- |
@@ -181,6 +218,8 @@ gh api repos/{owner}/{repo}/issues/<番号>/comments --paginate
 | `architecture` | 構成、レイヤ境界、依存の方向、設計判断とその理由 |
 | `dev-tip` | 開発・デバッグ・運用の勘所、ハマりどころと回避策 |
 | `code-convention` | コーディング規約、命名、レビューで繰り返し指摘される事項 |
+
+どのtypeにも収まらない知見が出た場合は、無理に押し込まず `deferred` に回し、type追加の要否を報告する。
 
 除外するもの:
 
@@ -207,9 +246,11 @@ ls .knowledge/*/
 **「同一テーマ」の判定基準** — 以下を上から順に当てる。
 
 1. `type` が異なれば別テーマ。同一ファイルにまとめない
-2. `type` が同じで、扱う対象（モジュール、概念、業務ルール）が同一なら同一テーマ → 既存を更新
-3. 対象は同じだが観点が異なる（例: 同じモジュールの「設計理由」と「デバッグの勘所」）→ `type` が違うはずなので別ファイル。同じなら既存ファイルにセクションを追加
+2. `type` が同じで、扱う対象（モジュール、概念、業務ルール）が同一なら同一テーマ → 既存ファイルを更新する
+3. `type` が同じで対象が異なるなら別ファイルを作る
 4. 判断がつかない場合は**新規作成せず**、既存ファイルへの追記を選ぶか、呼び出し側に確認する
+
+同じモジュールでも「設計理由」と「デバッグの勘所」は `type` が異なる（`architecture` と `dev-tip`）ため、規則1で自動的に別ファイルになる。
 
 ファイルが増えて `ls` だけで見通せなくなったら、`index.md` から各 type 配下の `index.md` へ分割し、階層化する。
 
@@ -219,9 +260,13 @@ ls .knowledge/*/
 
 #### ディレクトリ構成
 
+`pr-knowledge:init` が生成した構成に従う。ディレクトリは `config.json` の `types[].dir` を使い、**自分で新設しない。**
+
 ```
 .knowledge/
+├── config.json           # 設定（読み取りのみ。書き換えない）
 ├── index.md              # 全概念の一覧（type別）
+├── _template.md          # フロントマター雛形
 ├── features/
 ├── domain/
 ├── architecture/
@@ -233,14 +278,17 @@ ls .knowledge/*/
 
 #### フロントマター（OKF簡易版）
 
-OKFが必須とするのは `type` のみ。本バンドルでは以下を必須運用とする。
+新規ファイルは `_template.md` をコピーして埋める。**キー構成は `_template.md` が正。** `config.json` の `frontmatter` と食い違う場合はテンプレートに従い、不一致を報告する（設定の修正は `pr-knowledge:init` の責務）。
+
+本文は `config.json` の `language` で書く。
 
 ```yaml
 ---
-type: architecture          # 必須。上表の5値のいずれか
+type: architecture          # 必須。config.json の types[].id のいずれか
 title: 集約境界の切り方
 description: 一行要約
 tags: [ddd, 設計判断]         # 任意
+status: confirmed           # 任意。確度が低い場合のみ draft
 updated: 2026-08-25
 sources:
   - https://github.com/org/repo/pull/123
@@ -249,26 +297,14 @@ sources:
 
 #### 本文
 
-```markdown
-## 要点
+セクション構成は `config.json` の `body_sections` に従う（既定は 要点 / 詳細 / 注意点 / 関連）。
 
-（3行以内。ここだけ読めば伝わるように書く）
+- **要点** は3行以内。ここだけ読めば伝わるように書く
+- **詳細** は背景、理由、具体例。コード片は最小限に
+- **注意点** はハマりどころ、やってはいけないこと。無ければ省略可
+- **関連** は通常のMarkdownリンクで相互参照する。リンクを張ったら相手側にも逆リンクを追加する
 
-## 詳細
-
-（背景、理由、具体例。コード片は最小限に）
-
-## 注意点
-
-（あれば。ハマりどころ、やってはいけないこと）
-
-## 関連
-
-- [イベント設計の方針](../architecture/event-design.md)
-```
-
-- 関連概念は通常のMarkdownリンクで相互参照する。リンクを張ったら相手側にも逆リンクを追加する。
-- レビュー議論が出典の場合、該当スレッドの `html_url` を `## 詳細` 内に残すと後から辿れる。
+レビュー議論が出典の場合、該当スレッドの `html_url` を `## 詳細` 内に残すと後から辿れる。
 
 #### 追記のルール
 
@@ -286,15 +322,20 @@ sources:
 
 書き込み後に更新する。
 
+見出しは `config.json` の `types[].label` に一致させる。**見出しを追加・改名・削除しない。前文もそのまま残す。**
+
 ```markdown
 # Knowledge Index
 
-## architecture
+このディレクトリは pr-knowledge スキルが管理します。
+書式とベースブランチ等の設定は config.json を参照してください。
+
+## アーキテクチャ
 
 - [集約境界の切り方](architecture/aggregate-boundaries.md) — 集約をどこで割るかの判断基準
 ```
 
-`.knowledge/` が存在しない場合は、ディレクトリと `index.md` を新規作成してよい。
+`.knowledge/` やディレクトリが存在しない場合は**作成せず**、`pr-knowledge:init` の実行を促して停止する。
 
 ### 7. 報告する
 

--- a/skills/pr-knowledge/collect/SKILL.md
+++ b/skills/pr-knowledge/collect/SKILL.md
@@ -4,7 +4,7 @@ description: マージ済みPRから知見を抽出し .knowledge/ に蓄積す�
 license: MIT
 metadata:
   author: IsodaZen
-  version: "2.0.0"
+  version: "1.0.0"
 ---
 
 # PR知見蓄積スキル（collect）

--- a/skills/pr-knowledge/init/SKILL.md
+++ b/skills/pr-knowledge/init/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: init
+description: pr-knowledge:collect スキル用の知見バンドルを初期化する。ベースブランチやタイムゾーン、対象typeをヒアリングして .knowledge/config.json に確定させ、ディレクトリ構成・index.md・フロントマター雛形を生成する。「知見バンドルを初期化して」「.knowledge をセットアップして」「pr-knowledge の初期設定をして」のように呼ばれたときに使う。既に初期化済みのバンドルへの知見追記には使わない（pr-knowledge:collect を使う）。pr-knowledgeファミリー（pr-knowledge:collect / pr-knowledge:init / pr-knowledge:orchestrate）の初期化役。
+license: MIT
+metadata:
+  author: IsodaZen
+  version: "1.0.0"
+---
+
+# 知見バンドル初期化スキル（init）
+
+`pr-knowledge:collect` が使う `.knowledge/` バンドルを、リポジトリごとの設定込みで用意する。
+
+**このスキルの成果物は設定と器だけ。** 知見そのものは書かない。
+
+## 呼び出し
+
+引数は取らない。
+
+```
+$pr-knowledge:init
+```
+
+設定値は必ず手順2のヒアリングで確定させる。**引数や既存ファイルからの推測で埋めない。**
+
+## 手順
+
+### 1. 前提確認と冪等性チェック
+
+```bash
+git rev-parse --show-toplevel
+gh auth status
+gh repo view --json nameWithOwner,defaultBranchRef
+```
+
+満たさなければ停止して報告する。
+
+バンドルのルートは `.knowledge/` 固定。可変にしない。
+
+`.knowledge/config.json` が既に存在する場合:
+
+- **上書きしない。** 現在の設定を表示し、「変更したい項目があるか」を尋ねる
+- 変更指示があった項目だけを更新し、`schema_version` は据え置く
+- 変更がなければ、不足しているディレクトリ・ファイルだけを補完して終了する
+
+`config.json` が存在するがJSONとしてパースできない場合:
+
+- **自動修復しない。** パースエラーの内容を提示し、手で直すか作り直すかをユーザーに選ばせる
+- 作り直す場合のみ、破損ファイルを `config.json.broken` にリネームしてから手順2へ進む
+
+### 2. ヒアリング
+
+以下をまとめて提示し、既定値を示したうえで回答を求める。1問ずつ聞かない。
+
+| 項目 | 既定値 | 補足 |
+| :--- | :--- | :--- |
+| ベースブランチ | `gh repo view --json defaultBranchRef` の値 | **必ず確認する。** 複数可（`main` と `develop` の併用、リリースブランチ運用など）。ここを誤ると対象PRが丸ごとズレる |
+| タイムゾーン | システムのTZ、不明なら `UTC` | 日付境界の解釈に使う。GitHub検索はUTC基準なので、JST運用ならここで確定させる |
+| 対象type | `feature` `domain` `architecture` `dev-tip` `code-convention` | 追加・削除・リネーム可。リポジトリの性質に合わないtypeは外す |
+| 記述言語 | 直近のコミットメッセージ/PRタイトルから推定 | `ja` / `en` |
+| 除外する作成者 | `app/dependabot` `app/renovate` | bot PRをクエリ段階で落とす |
+| 除外するラベル | なし | `chore` `dependencies` などを運用しているなら指定 |
+
+ベースブランチについては、`defaultBranchRef` の値をそのまま既定として提示しつつ、**「リリースブランチやdevelopへのマージも対象にするか」を明示的に尋ねる。** GitHub Flow 以外の運用は既定値の推定が外れやすい。
+
+### 3. config.json を生成する
+
+`.knowledge/config.json` に書き出す。
+
+```json
+{
+  "schema_version": 1,
+  "repository": "org/repo",
+  "base_branches": ["main"],
+  "timezone": "Asia/Tokyo",
+  "language": "ja",
+  "types": [
+    { "id": "feature",         "dir": "features",          "label": "機能・仕様",     "description": "機能の振る舞い、仕様上の制約、既知のエッジケース" },
+    { "id": "domain",          "dir": "domain",            "label": "ドメイン知識",   "description": "業務ドメインの概念、用語、ビジネスルール" },
+    { "id": "architecture",    "dir": "architecture",      "label": "アーキテクチャ", "description": "構成、レイヤ境界、依存の方向、設計判断とその理由" },
+    { "id": "dev-tip",         "dir": "dev-tips",          "label": "開発Tips",       "description": "開発・デバッグ・運用の勘所、ハマりどころと回避策" },
+    { "id": "code-convention", "dir": "code-conventions",  "label": "コード規約",     "description": "コーディング規約、命名、レビューで繰り返し指摘される事項" }
+  ],
+  "exclude_authors": ["app/dependabot", "app/renovate"],
+  "exclude_labels": [],
+  "pr_search_limit": 100,
+  "frontmatter": {
+    "required": ["type", "title", "description", "updated", "sources"],
+    "optional": ["tags", "status"]
+  },
+  "status_values": ["confirmed", "draft"],
+  "body_sections": ["要点", "詳細", "注意点", "関連"],
+  "initialized_at": "2026-08-27"
+}
+```
+
+- `schema_version` は**このスキルとconfigの構造互換性**を表す。`pr-knowledge:collect` は自分が解釈できる版と一致しない場合に停止する。設定値を変更しただけでは上げない
+- `type` はOKFで唯一の必須フロントマターなので、`types[].id` がそのまま `type` の許容値になる。ここに無い値は `pr-knowledge:collect` 側で使わせない
+- `dir` は `.knowledge/` からの相対パス
+- `language` は知見本文の記述言語。`pr-knowledge:collect` はこれに従って書く
+- `status_values` は知見の確度。議論が未決着のまま記録する場合に `draft` を使う
+- 生成後に `python3 -m json.tool .knowledge/config.json` でパース検証する
+
+### 4. ディレクトリと雛形を生成する
+
+```
+.knowledge/
+├── config.json
+├── index.md
+├── _template.md
+├── features/.gitkeep
+├── domain/.gitkeep
+├── architecture/.gitkeep
+├── dev-tips/.gitkeep
+└── code-conventions/.gitkeep
+```
+
+`types` で選ばれたものだけ作る。既存ディレクトリは削除しない。
+
+#### `_template.md`
+
+フロントマターを定型化するための雛形。`pr-knowledge:collect` はこれを起点に新規ファイルを作る。
+
+```markdown
+---
+type:
+title:
+description:
+tags: []
+updated:
+sources:
+  -
+---
+
+## 要点
+
+## 詳細
+
+## 注意点
+
+## 関連
+```
+
+`config.json` の `frontmatter` と `body_sections` を変更した場合は、`_template.md` も必ず追従させる。**両者が食い違うとフォーマットが崩れる。**
+
+#### `index.md`
+
+`types[].label` から見出しだけを生成する。項目は空でよい。**`pr-knowledge:collect` が更新するのはこの見出しの配下だけで、前文は保持される。**
+
+```markdown
+# Knowledge Index
+
+このディレクトリは pr-knowledge スキルが管理します。
+書式とベースブランチ等の設定は config.json を参照してください。
+
+## 機能・仕様
+
+## ドメイン知識
+
+## アーキテクチャ
+
+## 開発Tips
+
+## コード規約
+```
+
+### 5. 検証して報告する
+
+- `config.json` がJSONとしてパースできること
+- `types[].dir` がすべて実在すること
+- `_template.md` のフロントマターキーが `config.json` の `frontmatter.required` を満たすこと
+- `index.md` の見出しが `types[].label` と一対一で対応すること
+
+報告内容:
+
+- 生成したファイル・ディレクトリ一覧
+- 確定した `base_branches` と `timezone`（**ここは必ず読み上げる。** 誤りが最も影響する項目）
+- 既定値のまま採用した項目
+- 次のアクション（`$pr-knowledge:collect <日付>` で運用開始できる旨）
+
+## 禁止事項
+
+- **既存の `config.json` を無確認で上書きしない**
+- **既存の知見ファイルを一切変更・削除しない**
+- **コミットしない。** 変更はワーキングツリーに残す
+- **知見の中身を書かない。** サンプル知見やダミーエントリも作らない

--- a/skills/pr-knowledge/init/SKILL.md
+++ b/skills/pr-knowledge/init/SKILL.md
@@ -83,7 +83,7 @@ gh repo view --json nameWithOwner,defaultBranchRef
   ],
   "exclude_authors": ["app/dependabot", "app/renovate"],
   "exclude_labels": [],
-  "pr_search_limit": 100,
+  "pr_search_limit": 500,
   "frontmatter": {
     "required": ["type", "title", "description", "updated", "sources"],
     "optional": ["tags", "status"]


### PR DESCRIPTION
pr-knowledge:collect no longer guesses base branches, timezone, or
knowledge types — it now reads them from .knowledge/config.json and
stops with a pointer to pr-knowledge:init when the bundle isn't
initialized or the config is invalid. Also adds status: draft support
for weakly-substantiated review conclusions, a pr_search_limit
overflow warning, and stricter type/frontmatter validation against
config.json and _template.md.

pr-knowledge:init is a new sibling skill in the pr-knowledge family
that interviews the user for base branches, timezone, types, language,
and exclusions, then generates config.json, the per-type directories,
index.md, and _template.md. It never writes knowledge content itself
and never overwrites an existing config without confirmation.